### PR TITLE
Remove "dotenv" from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@nestjs/typeorm": "^6.2.0",
     "class-transformer": "^0.2.3",
     "class-validator": "^0.11.0",
-    "dotenv": "^8.2.0",
     "dotenv-flow": "^3.1.0",
     "i": "^0.3.6",
     "mysql": "^2.18.1",


### PR DESCRIPTION
You don't need to have `dotenv` in your dependencies while you're using `dotenv-flow`.