### PR TITLE
Adicionado suporte para Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,9 @@
+FROM gitpod/workspace-full
+
+# Install custom tools, runtimes, etc.
+# For example "bastet", a command-line tetris clone:
+# RUN brew install bastet
+#
+# More information: https://www.gitpod.io/docs/config-docker/
+
+RUN npm install -g npm@7.5.2

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+image:
+  file: .gitpod.Dockerfile
+
+ports:
+  - port: 8080
+    onOpen: open-browser
+
+tasks:
+  - init: cp ./.env.example ./.env && npm install
+    command: npm run start


### PR DESCRIPTION
A ideia do GitPod é permitir que pessoas que não tenha um computador com Hardware bacana, ainda possa contribuir com o projeto já que vai está rodando tudo na nuvem.

O GitPod é gratuito para projetos open source

Dá para testar as configurações que eu fiz acessando essa URL:
https://gitpod.io/#https://github.com/felinto-dev/newschool-backend/tree/felinto-dev/develop

Se essa PR for aprovado, o link acima pode não mais funcionar. Neste caso, é só acessar adicionado gitpod.io + github do projeto. Assim:
https://gitpod.io/#https://github.com/NewSchoolApp/newschool-backend