### PR TITLE
Suporte para hot reload adicionado no gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,4 +6,6 @@ FROM gitpod/workspace-full
 #
 # More information: https://www.gitpod.io/docs/config-docker/
 
+ENV IS_GITPOD=true
+
 RUN npm install -g npm@7.5.2

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,8 +3,8 @@ image:
 
 ports:
   - port: 8080
-    onOpen: open-browser
+    onOpen: open-preview
 
 tasks:
   - init: cp ./.env.example ./.env && npm install
-    command: npm run start
+    command: npm run start:dev

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,8 @@ async function bootstrap() {
     .setVersion('1.0')
     .build();
   const document = SwaggerModule.createDocument(app, options);
-  SwaggerModule.setup('', app, document);
+
+  SwaggerModule.setup(process.env.IS_GITPOD ? '' : 'swagger', app, document);
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ async function bootstrap() {
     .setVersion('1.0')
     .build();
   const document = SwaggerModule.createDocument(app, options);
-  SwaggerModule.setup('swagger', app, document);
+  SwaggerModule.setup('', app, document);
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
Melhorei a configuração do gitpod adicionando suporte para hot reload.
Agora quando uma alteração é feita ela vai se refletir diretamente na API.

Também troquei a página inicial da API CASO esteja usando GitPod para o swagger.

A ideia é que quem iniciar o ambiente com o GitPod, já tenha tudo configurado e já tenha um ambiente pronto para testar as requests. Inclusive fazer modificações de um jeito rápido e fácil e já ver funcionando.
![Screenshot_304](https://user-images.githubusercontent.com/32253743/107647334-cfda2000-6c59-11eb-8f1d-1c6d5fe1431b.png)
